### PR TITLE
Added baseReporterDecorator

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,8 +2,10 @@ var createPattern = function (path) {
     return { pattern: path, included: true, served: true, watched: false };
 };
 
-var OrderReporter = function (config) {
+var OrderReporter = function (config, baseReporterDecorator) {
     const files = config.files;
+
+    baseReporterDecorator(this);
 
     files.splice(
         files.length - 1,
@@ -12,6 +14,8 @@ var OrderReporter = function (config) {
         createPattern(__dirname + '/lib/jasmine-order.adapter.js')
     );
 };
+
+OrderReporter.$inject = ['config', 'baseReporterDecorator'];
 
 module.exports = {
     "reporter:jasmine-order": ["type", OrderReporter]


### PR DESCRIPTION

![Screenshot 2021-01-19 at 16 43 59](https://user-images.githubusercontent.com/25486897/105057948-04512680-5a76-11eb-9564-d168d5f632fa.png)

Trying to run a single test in Intellij/PHPStorm causes the Karma Server to crash with the following output:

`19 01 2021 16:44:12.021:INFO [karma-server]: Karma v5.2.3 server started at http://localhost:9876/`
`19 01 2021 16:44:12.024:INFO [launcher]: Launching browsers ChromeHeadlessCI with concurrency unlimited`
`19 01 2021 16:44:12.028:INFO [launcher]: Starting browser ChromeHeadless`
`✔ Browser application bundle generation complete.`
`19 01 2021 16:44:20.402:INFO [Chrome Headless 87.0.4280.141 (Mac OS 10.15.7)]: Connected on socket gLWtLHOz03dwk78hAAAA with id 59490450`
`19 01 2021 16:44:20.546:WARN [karma]: Error during refresh file list. TypeError: Cannot read property 'push' of undefined`
`    at ...../node_modules/karma/lib/reporters/multi.js:11:61`
`    at Array.forEach (<anonymous>)`
`    at MultiReporter.addAdapter (..../node_modules/karma/lib/reporters/multi.js:11:21)`
`    at Server.<anonymous> (..../node_modules/karma/lib/middleware/runner.js:97:18)`
`    at Object.onceWrapper (node:events:434:26)`
`    at Server.emit (node:events:339:22)`
`    at Executor.schedule (..../node_modules/karma/lib/executor.js:31:20)`
`    at ..../node_modules/karma/lib/middleware/runner.js:42:18`
`19 01 2021 16:44:20.552:ERROR [karma-server]: UncaughtException:: Cannot read property 'write' of null`
`19 01 2021 16:44:20.558:ERROR [karma-server]: TypeError: Cannot read property 'write' of null`
`    at ..../Library/Application Support/JetBrains/PhpStorm2020.3/plugins/js-karma/js_reporter/karma-intellij/lib/intellijReporter.js:151:12`
`    at processTicksAndRejections (node:internal/process/task_queues:75:11)`
`19 01 2021 16:44:20.559:ERROR [karma-server]: UncaughtException:: Cannot read property 'write' of null`
`19 01 2021 16:44:20.559:ERROR [karma-server]: TypeError: Cannot read property 'write' of null`
`    at ...../Library/Application Support/JetBrains/PhpStorm2020.3/plugins/js-karma/js_reporter/karma-intellij/lib/intellijReporter.js:151:12`
`    at processTicksAndRejections (node:internal/process/task_queues:75:11)`

`Process finished with exit code 1`



Adding Karma's baseReporterDecorator solves this issue.